### PR TITLE
Fix: update mysql container to expose ports

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -35,6 +35,8 @@ services:
       MYSQL_DATABASE: Makelist
       MYSQL_USER: cpnv
       MYSQL_PASSWORD: 1234
+    ports:
+      - "3306:3306"
     volumes:
       - db-engine:/var/lib/mysql
     networks:

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,12 @@
 			<version>5.10.2</version>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<version>9.3.0</version>
+	</dependency>
+</dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/Makelist?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=1234
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,4 @@
 spring.application.name=makelist
-
-spring.datasource.url=jdbc:mysql://localhost:3306/Makelist?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=1234
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.profiles.active=mysql


### PR DESCRIPTION
# Fix: update mysql container to expose ports

This PR will fix the database microservice for the project

## Changes made

- Expose ports of the container
- Added `MySql` dependency
- Update `application.properties` to be able to switch from `H2` to `MySql`

