### PR TITLE
Feat: implement TierListItem backend

### DIFF
--- a/src/main/java/ch/etmles/makelist/Controllers/TierListController.java
+++ b/src/main/java/ch/etmles/makelist/Controllers/TierListController.java
@@ -17,38 +17,38 @@ public class TierListController {
     }
 
     /* curl sample :
-    curl -i localhost:8080/TierLists
+    curl -i localhost:8080/tierlists
     */
-    @GetMapping("/TierLists")
+    @GetMapping("/tierlists")
     List<TierList> all(){
         return repository.findAll();
     }
 
     /* curl sample :
-    curl -i -X POST localhost:8080/TierLists ^
+    curl -i -X POST localhost:8080/tierlists ^
         -H "Content-type:application/json" ^
         -d "{\"title\": \"Awesome tier list!\"}"
     */
-    @PostMapping("/TierLists")
+    @PostMapping("/tierlists")
     TierList newTierList(@RequestBody TierList newTierList){
         return repository.save(newTierList);
     }
 
     /* curl sample :
-    curl -i localhost:8080/TierLists/1
+    curl -i localhost:8080/tierlists/1
     */
-    @GetMapping("/TierLists/{id}")
+    @GetMapping("/tierlists/{id}")
     TierList one(@PathVariable Long id){
         return repository.findById(id)
                 .orElseThrow(() -> new TierListNotFoundException(id));
     }
 
     /* curl sample :
-    curl -i -X PUT localhost:8080/TierLists/2 ^
+    curl -i -X PUT localhost:8080/tierlists/2 ^
         -H "Content-type:application/json" ^
         -d "{\"title\": \"My updated tier list!\"}"
      */
-    @PutMapping("/TierLists/{id}")
+    @PutMapping("/tierlists/{id}")
     TierList updateTierList(@RequestBody TierList newTierList, @PathVariable Long id) {
         return repository.findById(id)
                 .map(tierList -> {
@@ -62,9 +62,9 @@ public class TierListController {
     }
 
     /* curl sample :
-    curl -i -X DELETE localhost:8080/TierLists/2
+    curl -i -X DELETE localhost:8080/tierlists/2
     */
-    @DeleteMapping("/TierLists/{id}")
+    @DeleteMapping("/tierlists/{id}")
     void deleteTierList(@PathVariable Long id){
         repository.deleteById(id);
     }

--- a/src/main/java/ch/etmles/makelist/Controllers/TierListController.java
+++ b/src/main/java/ch/etmles/makelist/Controllers/TierListController.java
@@ -4,6 +4,9 @@ import org.springframework.web.bind.annotation.*;
 
 import ch.etmles.makelist.Entities.TierList;
 import ch.etmles.makelist.Repositories.TierListRepository;
+import ch.etmles.makelist.clients.TierListItemClient;
+import ch.etmles.makelist.dtos.TierListItemDTO;
+import ch.etmles.makelist.dtos.TierListResponse;
 
 import java.util.List;
 
@@ -11,9 +14,11 @@ import java.util.List;
 public class TierListController {
 
     private final TierListRepository repository;
+    private final TierListItemClient tierListItemClient;
 
-    TierListController(TierListRepository repository){
+    TierListController(TierListRepository repository, TierListItemClient tierListItemClient){
         this.repository = repository;
+        this.tierListItemClient = tierListItemClient;
     }
 
     /* curl sample :
@@ -38,9 +43,13 @@ public class TierListController {
     curl -i localhost:8080/tierlists/1
     */
     @GetMapping("/tierlists/{id}")
-    TierList one(@PathVariable Long id){
-        return repository.findById(id)
+    public TierListResponse one(@PathVariable Long id){
+        TierList tierList = repository.findById(id)
                 .orElseThrow(() -> new TierListNotFoundException(id));
+        
+        List<TierListItemDTO> items = tierListItemClient.getItemsForTierList(id);
+
+        return new TierListResponse(tierList.getId(), tierList.getTitle(), items);
     }
 
     /* curl sample :

--- a/src/main/java/ch/etmles/makelist/Controllers/TierListItemController.java
+++ b/src/main/java/ch/etmles/makelist/Controllers/TierListItemController.java
@@ -1,0 +1,26 @@
+package ch.etmles.makelist.Controllers;
+
+import org.springframework.web.bind.annotation.*;
+
+import ch.etmles.makelist.Entities.TierListItem;
+import ch.etmles.makelist.Repositories.TierListItemRepository;
+
+import java.util.List;
+
+@RestController
+public class TierListItemController {
+
+    private final TierListItemRepository repository;
+
+    TierListItemController(TierListItemRepository repository){
+        this.repository = repository;
+    }
+
+    /* curl sample :
+    curl -i localhost:8080/tierlists/1/items
+    */
+    @GetMapping("/tierlists/{id}/items")
+    List<TierListItem> all(@PathVariable("id") Long tierListId){
+        return repository.findByTierListId(tierListId);
+    }
+}

--- a/src/main/java/ch/etmles/makelist/Controllers/TierListItemNotFoundAdvice.java
+++ b/src/main/java/ch/etmles/makelist/Controllers/TierListItemNotFoundAdvice.java
@@ -1,0 +1,18 @@
+package ch.etmles.makelist.Controllers;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class TierListItemNotFoundAdvice {
+
+    @ResponseBody
+    @ExceptionHandler(TierListItemNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    String TierListItemNotFoundHandler(TierListItemNotFoundException ex){
+        return ex.getMessage();
+    }
+}

--- a/src/main/java/ch/etmles/makelist/Controllers/TierListItemNotFoundException.java
+++ b/src/main/java/ch/etmles/makelist/Controllers/TierListItemNotFoundException.java
@@ -1,0 +1,8 @@
+package ch.etmles.makelist.Controllers;
+
+public class TierListItemNotFoundException extends RuntimeException{
+
+    TierListItemNotFoundException(Long id){
+        super("Could not find tierlist item " + id);
+    }
+}

--- a/src/main/java/ch/etmles/makelist/Entities/TierListItem.java
+++ b/src/main/java/ch/etmles/makelist/Entities/TierListItem.java
@@ -1,0 +1,60 @@
+package ch.etmles.makelist.Entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class TierListItem {
+
+    private @Id
+    @GeneratedValue Long id;
+    private String text;
+    private Short rank;
+    private Long tierListId;
+
+    public TierListItem(){}
+
+    public TierListItem(String text, Long tierListId){
+        this.setText(text);
+        this.setTierListId(tierListId);
+    }
+
+    public TierListItem(String text, Long tierListId, Short rank){
+        this.setText(text);
+        this.setTierListId(tierListId);
+        this.setRank(rank);
+    }
+
+    public Long getId(){
+        return this.id;
+    }
+
+    public void setId(Long id){
+        this.id = id;
+    }
+
+    public String getText(){
+        return this.text;
+    }
+
+    public void setText(String text){
+        this.text = text;
+    }
+
+    public Short getRank(){
+        return this.rank;
+    }
+
+    public void setRank(Short rank){
+        this.rank = rank;
+    }
+
+    public Long getTierListId(){
+        return this.tierListId;
+    }
+
+    public void setTierListId(Long tierListId){
+        this.tierListId = tierListId;
+    }
+}

--- a/src/main/java/ch/etmles/makelist/Repositories/LoadDatabase.java
+++ b/src/main/java/ch/etmles/makelist/Repositories/LoadDatabase.java
@@ -7,16 +7,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import ch.etmles.makelist.Entities.TierList;
+import ch.etmles.makelist.Entities.TierListItem;
 
 @Configuration
 public class LoadDatabase {
     private static final Logger log = LoggerFactory.getLogger(LoadDatabase.class);
 
     @Bean
-    CommandLineRunner initDatabase(TierListRepository repository){
+    CommandLineRunner initDatabase(TierListRepository tierListRepository, TierListItemRepository tierListItemRepository){
         return args->{
-            log.info("Preloading " + repository.save(new TierList("Awesome tier list!")));
-            log.info("Preloading " + repository.save(new TierList("Best vegetables")));
+            log.info("Preloading " + tierListRepository.save(new TierList("Awesome tier list!")));
+            log.info("Preloading " + tierListRepository.save(new TierList("Best vegetables")));
+            log.info("Preloading " + tierListItemRepository.save(new TierListItem("Radish", 2L, (short) 1)));
+            log.info("Preloading " + tierListItemRepository.save(new TierListItem("Carrot", 2L, (short) 4)));
         };
     }
 }

--- a/src/main/java/ch/etmles/makelist/Repositories/TierListItemRepository.java
+++ b/src/main/java/ch/etmles/makelist/Repositories/TierListItemRepository.java
@@ -1,0 +1,11 @@
+package ch.etmles.makelist.Repositories;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ch.etmles.makelist.Entities.TierListItem;
+
+public interface TierListItemRepository extends JpaRepository<TierListItem, Long>{
+    List<TierListItem> findByTierListId(Long tierListId);
+}

--- a/src/main/java/ch/etmles/makelist/clients/TierListItemClient.java
+++ b/src/main/java/ch/etmles/makelist/clients/TierListItemClient.java
@@ -1,0 +1,28 @@
+package ch.etmles.makelist.clients;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import ch.etmles.makelist.dtos.TierListItemDTO;
+
+@Service
+public class TierListItemClient {
+    private final RestTemplate restTemplate;
+
+    public TierListItemClient(RestTemplateBuilder builder) {
+        this.restTemplate = builder.build();
+    }
+
+    public List<TierListItemDTO> getItemsForTierList(Long tierListId) {
+        ResponseEntity<TierListItemDTO[]> response = restTemplate.getForEntity(
+            "http://localhost:8080/tierlists/" + tierListId + "/items",
+            TierListItemDTO[].class
+        );
+        return Arrays.asList(response.getBody());
+    }
+}

--- a/src/main/java/ch/etmles/makelist/config/RestTemplateConfig.java
+++ b/src/main/java/ch/etmles/makelist/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package ch.etmles.makelist.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/ch/etmles/makelist/dtos/TierListItemDTO.java
+++ b/src/main/java/ch/etmles/makelist/dtos/TierListItemDTO.java
@@ -1,0 +1,31 @@
+package ch.etmles.makelist.dtos;
+
+public class TierListItemDTO {
+    private Long id;
+    private String text;
+    private Long tierListId;
+    private Short rank;
+
+    public TierListItemDTO(Long id, String text, Short rank, Long tierListId) {
+        this.id = id;
+        this.text = text;
+        this.tierListId = tierListId;
+        this.rank = rank;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public Long getTierListId() {
+        return tierListId;
+    }
+
+    public Short getRank() {
+        return rank;
+    }
+}

--- a/src/main/java/ch/etmles/makelist/dtos/TierListResponse.java
+++ b/src/main/java/ch/etmles/makelist/dtos/TierListResponse.java
@@ -1,0 +1,26 @@
+package ch.etmles.makelist.dtos;
+
+import java.util.List;
+
+public class TierListResponse {
+    private Long id;
+    private String title;
+    private List<TierListItemDTO> items;
+
+    public TierListResponse(Long id, String title, List<TierListItemDTO> items) {
+        this.id = id;
+        this.title = title;
+        this.items = items;
+    }
+
+    public Long getId(){
+        return id; 
+    }
+
+    public String getTitle(){
+        return title;
+    }
+    public List<TierListItemDTO> getItems(){
+        return items;
+    }
+}


### PR DESCRIPTION
# Feat: implement TierListItem backend

This PR will add the implementation of the tier list item backend

## Changes made

- Created the different classes for tier list item based off the class diagram (controller, entity, repository, etc.)
- Implemented the get route
- Modified the `/tierlists/{id}` route to call the `TierListItem` controller
- Implemented DTOs and Client classes to communicate between the two services.
- Refactored the API routes to be lowercase